### PR TITLE
Correct "nanonseconds" to "nanoseconds"

### DIFF
--- a/index.html
+++ b/index.html
@@ -1868,7 +1868,7 @@ li.menu-search-result-term:before {
         </tr>
         <tr>
           <td>[[Nanoseconds]]</td>
-          <td><code>"nanonseconds"</code></td>
+          <td><code>"nanoseconds"</code></td>
         </tr>
       </tbody></table>
     </figure></emu-table>
@@ -1935,7 +1935,7 @@ li.menu-search-result-term:before {
 
       <ul>
         <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]].[[nu]] must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">List</a></emu-xref> as specified in  <emu-xref href="#sec-intl.numberformat-internal-slots"><a href="https://tc39.github.io/ecma402/#sec-intl.numberformat-internal-slots">12.3.3</a></emu-xref>.</li>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[formats]] field. The value of this field must be a record, which must have fields with the names of the four formatting styles: <code>long</code>, <code>short</code>, <code>narrow</code>, and <code>dotted</code>. Each of first three fields must be records themselves, and each must have fields with the names of the supported units: <code>nanonseconds</code>, <code>microseconds</code>, <code>milliseconds</code>, <code>seconds</code>, <code>minutes</code>, <code>hours</code>, <code>days</code>, <code>weeks</code>, <code>months</code>, and <code>years</code>, which are Records with a field for each of the plural categories relevant for <var>locale</var>; the value corresponding to those fields is a pattern which may contain "{0}" to be replaced by a formatted number. The value of the fourth field, corresponding to the <code>dotted</code> style, on the other hand, should be a pattern; i.e. a String that contains for an arbitrary subset of the Duration component fields a substring starting with <code>"{"</code>, followed by the name of the field, followed by <code>"}"</code>.</li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[formats]] field. The value of this field must be a record, which must have fields with the names of the four formatting styles: <code>long</code>, <code>short</code>, <code>narrow</code>, and <code>dotted</code>. Each of first three fields must be records themselves, and each must have fields with the names of the supported units: <code>nanoseconds</code>, <code>microseconds</code>, <code>milliseconds</code>, <code>seconds</code>, <code>minutes</code>, <code>hours</code>, <code>days</code>, <code>weeks</code>, <code>months</code>, and <code>years</code>, which are Records with a field for each of the plural categories relevant for <var>locale</var>; the value corresponding to those fields is a pattern which may contain "{0}" to be replaced by a formatted number. The value of the fourth field, corresponding to the <code>dotted</code> style, on the other hand, should be a pattern; i.e. a String that contains for an arbitrary subset of the Duration component fields a substring starting with <code>"{"</code>, followed by the name of the field, followed by <code>"}"</code>.</li>
       </ul>
 
       <emu-note type="editor"><span class="note">Editor's Note</span><div class="note-contents">TODO: [[formats]].[[dotted]] need to be keyed by the available fields.</div></emu-note>


### PR DESCRIPTION
The word "nanoseconds" is misspelled as "nanonseconds" in two places in the spec. This PR corrects both misspellings.